### PR TITLE
Initial release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,22 +7,53 @@ resolve-link
 
 Resolve complete/partial URLs against a canonical target URL
 
+This library was built to resolve URLs when candidates submit incompleted URLs (e.g. missing protocol, username only).
+
+.. code:: python
+
+    # Username only
+    resolve_link('underdogio', 'https://github.com/')
+        # https://github.com/underdogio
+
+    # Missing protocol
+    resolve_link('www.linkedin.com/in/toddwolfson', 'https://www.linkedin.com/')
+        # https://www.linkedin.com/in/toddwolfson
+
+    # Custom website
+    resolve_link('https://underdog.io/', 'https://www.linkedin.com/')
+        # https://underdog.io/
+
+    # Complete URL
+    resolve_link('https://github.com/underdogio', 'https://github.com/')
+        # https://github.com/underdogio
+
+This is a port of our JavaScript library `resolve-link`_.
+
+.. _`resolve-link`: http://github.com/underdogio/resolve-link
+
 Getting Started
 ---------------
 Install the module with: ``pip install resolve_link``
 
 .. code:: python
 
-    from resolve_link import run
-    run()
+    from resolve_link import resolve_link
+    resolve_link('underdogio', 'https://github.com/')  # https://github.com/underdogio
 
 Documentation
 -------------
-_(Coming soon)_
+We expose ``resolve_link`` via our package ``resolve_link``.
 
-Examples
---------
-_(Coming soon)_
+resolve_link(src_url, target_url)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Resolve the best variation of ``src_url`` with respect to our ``target_url``
+
+- src_url ``str`` - URL/partial URL to be resolving from
+- target_url ``str`` - Canonical URL to try to match if on the same domain
+
+**Returns:**
+
+- ret_val ``str`` - Completed URL formatted via ``urllib.parse``
 
 Contributing
 ------------

--- a/docs/getting_started.py
+++ b/docs/getting_started.py
@@ -1,0 +1,2 @@
+from resolve_link import resolve_link
+print(resolve_link('underdogio', 'https://github.com/'))  # https://github.com/underdogio

--- a/resolve_link/__init__.py
+++ b/resolve_link/__init__.py
@@ -1,0 +1,66 @@
+# Load in our dependencies
+import re
+try:
+    from urlparse import urlsplit, urlunsplit
+except ImportError:
+    from urllib.parse import urlsplit, urlunsplit
+
+# Define our constants
+TLD_REGEXP = r'\.([a-zA-Z]*?)$'
+
+
+# Define our library
+def resolve_link(src_url, target_url):
+    """Resolve complete/partials URLs against canonical target URL
+
+    :param str src_url: URL/partial URL to be resolving from
+    :param str target_url: Canonical URL to try to match if on the same domain
+    :returns str ret_val: Completed URL formatted via `urllib.parse`
+    """
+    # Parse the src URL
+    src_url_parts = urlsplit(src_url)
+
+    # If there isn't a scheme (e.g. no `http://`)
+    if not src_url_parts.scheme:
+        # With no scheme, we have everything in path. Add on `//` and force treatment of `netloc`
+        tmp_src_url = '//{src_url}'.format(src_url=src_url)
+        tmp_src_url_parts = urlsplit(tmp_src_url)
+
+        # If this new hostname has a TLD (e.g. `google.com`), then keep it as the `src_url`
+        # DEV: We are trading accuracy for size (technically not all dots mean a tld)
+        #   If we want to be accurate, use the Python equivalent of https://github.com/ramitos/tld.js/blob/305a285fd8f5d618417178521d8729855baadb37/src/tld.js
+        if (tmp_src_url_parts.netloc and re.search(TLD_REGEXP, tmp_src_url_parts.netloc)):
+          src_url = tmp_src_url
+          src_url_parts = tmp_src_url_parts
+
+    # Convert our `namedtuple` of `src_url_parts` to an ordered dict to make it editable
+    # https://hg.python.org/cpython/file/2.7/Lib/urlparse.py#l121
+    # https://docs.python.org/2/library/collections.html#collections.somenamedtuple._asdict
+    src_url_dict = src_url_parts._asdict()
+
+    # Fallback path (e.g. `/hello` in `www.google.com/hello`)
+    if src_url_dict['path'] == '':
+        src_url_dict['path'] = '/'
+
+    # If we still have no `scheme` (e.g. no `http://`)
+    if src_url_dict['scheme'] == '':
+        # Parse our target URL
+        target_url_parts = urlsplit(target_url)
+
+        # If the src URL has a `netloc` (e.g. `www.google.com`)
+        if src_url_dict['netloc']:
+          # If the target `netloc` is the same as our original, add on the target schem (e.g. `http://`)
+          if src_url_dict['netloc'] == target_url_parts.netloc:
+            src_url_dict['scheme'] = target_url_parts.scheme
+          # Otherwise, default to HTTP
+          else:
+            src_url_dict['scheme'] = 'http'
+        # Otherwise, pickup the target scheme and netloc
+        else:
+          src_url_dict['scheme'] = target_url_parts.scheme
+          src_url_dict['netloc'] = target_url_parts.netloc
+
+    # Return the completed src URL
+    # https://docs.python.org/2/library/urlparse.html#urlparse.urlsplit
+    return urlunsplit((src_url_dict['scheme'], src_url_dict['netloc'], src_url_dict['path'],
+                       src_url_dict['query'], src_url_dict['fragment']))

--- a/resolve_link/resolve_link.py
+++ b/resolve_link/resolve_link.py
@@ -1,2 +1,0 @@
-def run():
-    pass

--- a/resolve_link/test/test.py
+++ b/resolve_link/test/test.py
@@ -1,7 +1,72 @@
-from unittest import TestCase
+# Load in our dependencies
+import unittest
 from resolve_link import resolve_link
 
 
-class TestRunFunction(TestCase):
-    def test_run_exists(self):
-        self.assertTrue(bool(resolve_link.run))
+# Start our tests
+class ResolveLinkTestCase(unittest.TestCase):
+    def test_complete_url(self):
+        """
+        A complete HTTP URL to our target site when resolved
+            points to the original URL
+        """
+        result = resolve_link('https://www.linkedin.com/in/toddwolfson', 'https://www.linkedin.com/')
+        self.assertEqual(result, 'https://www.linkedin.com/in/toddwolfson')
+
+    def test_no_protocol(self):
+        """
+        An HTTP URL without a protocol to our target site when resolved
+            points to the original URL with a protocol
+        """
+        result = resolve_link('www.linkedin.com/in/toddwolfson', 'https://www.linkedin.com/')
+        self.assertEqual(result, 'https://www.linkedin.com/in/toddwolfson')
+
+    def test_path(self):
+        """
+        An HTTP URL with an unexpected path to our target site when resolved
+            points to the original URL
+        """
+        result = resolve_link('https://www.linkedin.com/pub/toddwolfson/aa/bb/cc', 'https://www.linkedin.com/')
+        self.assertEqual(result, 'https://www.linkedin.com/pub/toddwolfson/aa/bb/cc')
+
+    def test_query_string(self):
+        """
+        An HTTP URL with a query string to our target site when resolved
+            points to the original URL
+        """
+        result = resolve_link('https://www.linkedin.com/profile/view?id=87904336&trk=nav_responsive_tab_profile_pic',
+                              'https://www.linkedin.com/')
+        self.assertEqual(result,
+                         'https://www.linkedin.com/profile/view?id=87904336&trk=nav_responsive_tab_profile_pic')
+
+    def test_custom_site(self):
+        """
+        An HTTP URL to a custom site when resolved
+            points to the original URL
+        """
+        result = resolve_link('http://underdog.io/', 'https://www.linkedin.com/')
+        self.assertEqual(result, 'http://underdog.io/')
+
+    def test_custom_no_pathname(self):
+        """
+        An HTTP URL without a pathname to a custom site when resolved
+            points to the original URL with a pathname
+        """
+        result = resolve_link('http://underdog.io', 'https://www.linkedin.com/')
+        self.assertEqual(result, 'http://underdog.io/')
+
+    def test_custom_site_no_protocol(self):
+        """
+        An HTTP URL without a protocol to a custom site when resolved
+            points to the original URL with a protocol and pathname
+        """
+        result = resolve_link('underdog.io', 'https://www.linkedin.com/')
+        self.assertEqual(result, 'http://underdog.io/')
+
+    def test_username(self):
+        """
+        A username to our target site when resolved
+            points to the username on the target site
+        """
+        result = resolve_link('underdogio', 'https://github.com/')
+        self.assertEqual(result, 'https://github.com/underdogio')

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,1 @@
-nosetests --nocapture
+nosetests --nocapture $* resolve_link/test/*.py


### PR DESCRIPTION
This is mostly a direct port from our JS `resolve-link`. There was a bit of trouble with updating the named tuple that `urlsplit` returns. Everything beyond that everything was straightforward.

https://github.com/underdogio/resolve-link

In this PR:
- Ported tests
- Ported library
- Ported documentation

/cc @cmuir @brettlangdon 
