### PR TITLE
Fixed non-ascii string issue. Fixes #2

### DIFF
--- a/resolve_link/test/test.py
+++ b/resolve_link/test/test.py
@@ -70,3 +70,14 @@ class ResolveLinkTestCase(unittest.TestCase):
         """
         result = resolve_link('underdogio', 'https://github.com/')
         self.assertEqual(result, 'https://github.com/underdogio')
+
+    def test_unicode_username(self):
+        """
+        A unicode username to our target site when resolved
+            has no errors
+            points to the username on the target site
+
+        This is a regression test for https://github.com/underdogio/python-resolve-link/issues/2
+        """
+        result = resolve_link(u'underdogi\xf5', 'https://github.com/')
+        self.assertEqual(result, u'https://github.com/underdogi\xf5')


### PR DESCRIPTION
As reported in #2, we had a regression with `non-ascii` strings. This PR repairs that. In this PR:
- Added regression test
- Updated library to work with encoded strings internally

/cc @brettlangdon 
