### PR TITLE
Moved from supporting latin-1 to utf-8

### DIFF
--- a/resolve_link/__init__.py
+++ b/resolve_link/__init__.py
@@ -32,7 +32,7 @@ def resolve_link(src_url, target_url):
     # If the `src_url` is encoded, decode it
     encoding = None
     if _is_unicode(src_url):
-        encoding = 'latin-1'
+        encoding = 'utf-8'
         src_url = src_url.encode(encoding)
 
     # Parse the src URL

--- a/resolve_link/test/test.py
+++ b/resolve_link/test/test.py
@@ -71,9 +71,9 @@ class ResolveLinkTestCase(unittest.TestCase):
         result = resolve_link('underdogio', 'https://github.com/')
         self.assertEqual(result, 'https://github.com/underdogio')
 
-    def test_unicode_username(self):
+    def test_latin_1_username(self):
         """
-        A unicode username to our target site when resolved
+        A latin-1 username to our target site when resolved
             has no errors
             points to the username on the target site
 
@@ -81,3 +81,21 @@ class ResolveLinkTestCase(unittest.TestCase):
         """
         result = resolve_link(u'underdogi\xf5', 'https://github.com/')
         self.assertEqual(result, u'https://github.com/underdogi\xf5')
+
+    def test_unicode_username(self):
+        """
+        A unicode username to our target site when resolved
+            has no errors
+            points to the username on the target site
+        """
+        result = resolve_link(u'underdogi\ue0a4', 'https://github.com/')
+        self.assertEqual(result, u'https://github.com/underdogi\ue0a4')
+
+    def test_unicode_netloc(self):
+        """
+        A unicode net location when resolved
+            has no errors
+            points to the same location
+        """
+        result = resolve_link(u'http://www.\ue0a4.com/', 'https://github.com/')
+        self.assertEqual(result, u'http://www.\ue0a4.com/')


### PR DESCRIPTION
While `latin-1` is the exclusive set of what URLs should be composed of, we encounter `utf-8` characters/errors in production. As a result, we are moving to test against `utf-8` over `latin-1` to reduce the likelihood of errors. In this PR:
- Updated test name to reflect `latin-1` support more accurately
- Added tests for `utf-8` support
- Updated library to use `utf-8` encoding/decoding

/cc @brettlangdon 
